### PR TITLE
Fix Dutch translation in languages.xml

### DIFF
--- a/src/xml/languages.xml
+++ b/src/xml/languages.xml
@@ -70,7 +70,7 @@
 		<locales>nl_NL</locales>
 		<android>nl</android>
 		<browser>nl-NL</browser>
-		<title>Sistema periódico</title>
+		<title>Periodiek syteem</title>
 	</lang>
 
 	<lang>


### PR DESCRIPTION
The Dutch title was incorrect being in Spanish.
This fixes the little mistake