### PR TITLE
Added and fixed translations to languages in pt-BR

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -287,13 +287,13 @@ msgid "Hungarian"
 msgstr "Húngaro"
 
 msgid "Belarusian"
-msgstr "Bielorrussa"
+msgstr "Bielorrusso"
 
 msgid "Croatian"
-msgstr "Croácia"
+msgstr "Croata"
 
 msgid "Turkish"
-msgstr ""
+msgstr "Turco"
 
 msgid "Finnish"
-msgstr ""
+msgstr "Finlandês"


### PR DESCRIPTION
### Proposed changes

- 'Croatian' was written as 'Croácia' - that's the country, not the language - fixed to 'Croata'
- 'Bielorrussa' should be 'Bielorusso' as the portuguese word for 'language', 'idioma' is male
- Added translations for 'Turkish' and 'Finnish'